### PR TITLE
Sicronização manual de cursos com o Apolo

### DIFF
--- a/block_extensao.php
+++ b/block_extensao.php
@@ -3,27 +3,19 @@
 require_once('src/Service/Query.php');
 require_once('vendor/autoload.php');
 
-use block_extensao\Service\Query;
-
-use Carbon\Carbon;
-
 class block_extensao extends block_base {
     public function init() {
         $this->title = 'em dev';
     }
 
     public function get_content() {
-        global $USER;
-        
+        global $USER, $OUTPUT;
         $this->content =  new stdClass;
 
-        $cursos = Query::coursesFromThispYear();
-        $this->content->text = "$USER->idnumber ";
-        foreach($cursos as $curso) {
-            $date = Carbon::parse($curso['dtainc'])->format('d/m/Y');
-            $this->content->text .= "<li>{$curso['nomcurceu']} {$date} </li>";
-        }    
-
+        // template
+        $info = array('urlPaginaSincronizar' => new moodle_url('/blocks/extensao/pages/sincronizar.php'));
+        $this->content->text = $OUTPUT->render_from_template('block_extensao/extensao_block', $info);
+        
         return $this->content;
     }
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="blocks/extensao/db" VERSION="20230208" COMMENT="XMLDB file for Moodle blocks/extensao"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="block_extensao" COMMENT="Default comment for block_extensao, please edit me">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="extensao_turma" COMMENT="Para armazenar informaco
+    es de turma e curso.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="id_turma_apolo" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Id da turma no Apolo."/>
+        <FIELD NAME="id_curso_apolo" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Id do curso no Apolo."/>
+        <FIELD NAME="nome_curso_apolo" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Nome do curso no Apolo."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="extensao_usuario" COMMENT="Para armazenar a conexão entre um usuario no Apolo e o mesmo usuário no Moodle.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="id_moodle" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Id do usuario no Moodle."/>
+        <FIELD NAME="id_apolo" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Id do usuario no Apolo."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="fk_id_moodle" TYPE="foreign" FIELDS="id_moodle" REFTABLE="mdl_user" REFFIELDS="id" COMMENT="Chave estrangeira para o id_moodle"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="extensao_usuario_curso" COMMENT="Para relacionar os usuarios com os cursos.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="nusp_usuario" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Numero USP do usuario."/>
+        <FIELD NAME="id_turma_apolo" TYPE="INT" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Id da turma no Apolo."/>
+        <FIELD NAME="papel_usuario" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Papel do usuario (i.e., se eh aluno, docente, monitor, etc)."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/db/install.xml
+++ b/db/install.xml
@@ -35,7 +35,7 @@
         <KEY NAME="fk_id_moodle" TYPE="foreign" FIELDS="id_moodle" REFTABLE="mdl_user" REFFIELDS="id" COMMENT="Chave estrangeira para o id_moodle"/>
       </KEYS>
     </TABLE>
-    <TABLE NAME="extensao_usuario_curso" COMMENT="Para relacionar os usuarios com os cursos.">
+    <TABLE NAME="extensao_usuario_turma" COMMENT="Para relacionar os usuarios com os cursos.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="nusp_usuario" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Numero USP do usuario."/>

--- a/pages/sincronizar.php
+++ b/pages/sincronizar.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Sincronizacao Provisoria
+ * 
+ * Pagina para fazer a sincronizacao com o Apolo enquanto ela nao eh
+ * feita automaticamente de outra forma.
+ */
+
+// Configuracoes da pagina
+require_once('../../../config.php');
+global $PAGE, $OUTPUT;
+
+$PAGE->set_heading(get_string('pluginname', 'block_extensao'));
+$PAGE->set_pagelayout('admin');
+require_login();
+
+// cabecalho
+print $OUTPUT->header();
+
+// template
+$info = array(
+  'urlSincronizar' => new moodle_url('/blocks/extensao/src/sincronizar.php'),
+  'urlCancelar' => new moodle_url($CFG->wwwroot)
+);
+print $OUTPUT->render_from_template('block_extensao/sincronizar', $info);
+
+// rodape
+print $OUTPUT->footer();

--- a/src/Service/Extraction/Queries/alunos_extensao.sql
+++ b/src/Service/Extraction/Queries/alunos_extensao.sql
@@ -1,0 +1,26 @@
+/*  
+Informação sobre os alunos e os seus cursos
+*/
+
+ SELECT 
+        CM.codmtrcurceu AS 'CodMatricula'
+        ,CM.codcurceu AS 'CodCurso'
+        ,CM.codpes AS 'NUSP'
+        ,CM.stamtrcurceu AS 'StatusMatricula'
+        ,CM.codcurceu AS 'CodCurso1'
+        ,C.nomcurceu AS 'NomeCurso'
+        ,C.codcurceu AS 'CodCurso2'
+        ,P.nompes AS 'NomePessoa'
+        ,P.codpes AS 'NUSP1'
+        ,ED.codcurceu AS 'codCursoExtensao'
+        ,ED.codedicurceu  AS 'EdCurso'
+        ,ED.dtainiofeedi AS 'InicioCurso'
+        ,ED.dtafimofeedi AS 'FimCurso'
+        FROM 
+         MATRICULACURSOCEU CM
+    LEFT JOIN CURSOCEU C
+        ON CM.codcurceu = C.codcurceu
+    RIGHT JOIN PESSOA P
+        ON CM.codpes = P.codpes 
+    RIGHT JOIN EDICAOCURSOOFECEU ED
+        ON ED.codcurceu = C.codcurceu WHERE ED.dtainiofeedi LIKE '%2023%'

--- a/src/Service/Extraction/Queries/cursos_extensao.sql
+++ b/src/Service/Extraction/Queries/cursos_extensao.sql
@@ -1,0 +1,33 @@
+/*  
+Informação sobre o professor  
+Código do tipo de atuação: 1- Docente USP, 2- Esp. Externo, 3- Monitor, 4- Servidor, 5- Docente Colaborador
+*/
+
+ SELECT 
+        M.codofeatvceu AS 'Codoferecimentoatv'
+        ,M.codpes AS 'NUSP'
+        ,P.codpes AS 'NUSP1'
+        ,P.nompes AS 'NomeMinistrante'
+        ,M.codatc AS 'CodAtuacao'
+        ,O.codcurceu AS 'CodCurso'
+        ,O.codatvceu AS 'CodAtividade'
+        ,O.codofeatvceu AS 'Codoferecimentoatv2'
+        ,O.dtainiofeatv AS 'Inicio'
+        ,O.dtafimofeatv AS 'Fim'
+        ,C.nomcurceu AS 'NomeCurso'
+        ,C.codcurceu AS 'codCursoExtensao1'
+        ,ED.codcurceu AS 'codCursoExtensao'
+        ,ED.codedicurceu  AS 'EdCurso'
+        ,ED.dtainiofeedi AS 'InicioCurso'
+        ,ED.dtafimofeedi AS 'FimCurso'
+        FROM 
+        MINISTRANTECEU M
+    LEFT JOIN PESSOA P
+        ON M.codpes = P.codpes
+    RIGHT JOIN OFERECIMENTOATIVIDADECEU O 
+       ON M.codofeatvceu = O.codofeatvceu
+    RIGHT JOIN CURSOCEU C
+    	ON C.codcurceu = O.codcurceu
+    RIGHT JOIN EDICAOCURSOOFECEU ED
+        ON ED.codcurceu = C.codcurceu
+

--- a/src/Service/Query.php
+++ b/src/Service/Query.php
@@ -6,10 +6,50 @@ require_once('USPDatabase.php');
 
 class Query 
 {
-    public static function coursesFromThispYear(){
-        $year = date('Y');
-        $query = "SELECT codcurceu,nomcurceu,dtainc FROM CURSOCEU WHERE dtainc LIKE '%{$year}%'";
-        return USPDatabase::fetchAll($query);
-    }
+  public static function coursesFromThispYear(){
+    $year = date('Y');
+    $query = "SELECT codcurceu,nomcurceu,dtainc FROM CURSOCEU WHERE dtainc LIKE '%{$year}%'";
+    return USPDatabase::fetchAll($query);
+  }
 
+  public static function turmasAbertas () {
+    /**
+     * Captura as turmas abertas.
+     * Sao consideradas como turmas abertas somente as turmas com
+     * data de encerramento posterior a data de hoje.
+     *
+     * Nesse momento tambem, o que nos interessa eh quem tem o
+     * tipo de atuacao como 1, 2 ou 5 somente (eh isso mesmo?)
+     */
+    $hoje = date("Y-m-d");
+    $query = "
+      SELECT 
+            M.codofeatvceu AS 'Codoferecimentoatv'
+            ,P.codpes AS 'NUSP'
+            ,M.codatc AS 'CodAtuacao'
+            ,O.codcurceu AS 'CodCurso'
+            ,O.codatvceu AS 'CodAtividade'
+            ,O.dtainiofeatv AS 'Inicio'
+            ,O.dtafimofeatv AS 'Fim'
+            ,C.nomcurceu AS 'NomeCurso'
+            ,ED.codcurceu AS 'codCursoExtensao'
+            ,ED.codedicurceu  AS 'EdCurso'
+            FROM 
+            MINISTRANTECEU M
+        LEFT JOIN PESSOA P
+            ON M.codpes = P.codpes
+        RIGHT JOIN OFERECIMENTOATIVIDADECEU O 
+           ON M.codofeatvceu = O.codofeatvceu
+        RIGHT JOIN CURSOCEU C
+          ON C.codcurceu = O.codcurceu
+        RIGHT JOIN EDICAOCURSOOFECEU ED
+            ON ED.codcurceu = C.codcurceu
+        WHERE 
+          O.dtafimofeatv > '$hoje'
+          AND
+          M.codatc IN (1, 2, 5)
+    ";
+    return USPDatabase::fetchAll($query);
+  }
+  
 }

--- a/src/Service/USPDatabase.php
+++ b/src/Service/USPDatabase.php
@@ -14,21 +14,22 @@ class USPDatabase
         global $CFG;
 
         $host = get_config('block_extensao','host');
-        
-        //var_dump($host); die();
-
         $port = get_config('block_extensao','port');
         $db   = get_config('block_extensao','database');
         $user = get_config('block_extensao','user');
         $pass = get_config('block_extensao','password');
 
+        if (empty($host) or empty($port) or empty($db) or empty($user) or empty($pass)) {
+            echo "As credenciais de conexão estão vazias.";
+            return false;
+        } 
         if (!self::$instance) {
             try {
                 $dsn = "dblib:host={$host}:{$port};dbname={$db};charset=UTF-8";
                 self::$instance = new PDO($dsn,$user,$pass);
                 self::$instance->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
             } catch (\Throwable $t) {
-                #print_r($t->getMessage());
+                // print_r($t->getMessage()) . '<br>';
                 echo "Erro na conexão com o database do replicado! Contate o suporte";
                 die();
             }
@@ -83,7 +84,7 @@ class USPDatabase
             }
             $stmt->execute();
         } catch (\Throwable $t) {
-            #print_r($t->getMessage());
+            // print_r($t->getMessage());
             echo "Erro Interno no replicado: contate o suporte!";
             return false;
         }

--- a/src/sincronizar.php
+++ b/src/sincronizar.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * Sincronizar
+ * 
+ * A ideia desse arquivo eh fazer o servico de sincronizacao. Nao sei bem onde
+ * deixa-lo, entao por hora vou deixar aqui. Ele vai chamar a classe de queries 
+ * e buscar os dados no Apolo, e em seguida vai salvar as informacoes obtidas
+ * dentro da base interna do Moodle.
+ * 
+ * Depois de tudo isso, seria bom ele voltar pra tela da view com uma mensagem
+ * qualquer de 'sucesso' (se der certo).
+ * 
+ * Seria bom a gente estabelecer um fator para limitar a busca e tal. Buscar as
+ * turmas de um ano so pode dar problemas se for generalizado, entao eh bom 
+ * fazermos algo bem pensado.
+ */
+
+require_once('../../../config.php');
+require_once('Service/Query.php');
+use block_extensao\Service\Query;
+ 
+class Sincronizar {
+
+  // Captura as turmas atuais no Apolo e registra na base Moodle
+  public function sincronizar () {
+    
+    /**
+     * Capturar turmas
+     * 
+     * A ideia eh que essa funcao retorne um array das turmas, trazendo as
+     * informacoes relativas aos cursos.
+     * [ nome arbitrario so pra definir ]
+     */
+    echo 'começando<br>';
+    $turmas = Query::turmasAbertas();
+    // monta o array que sera adicionado na mdl_extensao_turma
+    $infos_turma = $this->filtrarInfosTurmas($turmas);
+
+    // pega as turmas que nao estao na base
+    $infos_turma = $this->turmasNaBase($infos_turma);
+
+    // se estiver vazio nao tem por que continuar
+    if (empty($infos_turma)) {
+      \core\notification::success('A base já estava sincronizada!');
+      $url = new moodle_url('/blocks/extensao/pages/sincronizar.php');
+      redirect($url);
+      // return false;
+    }
+
+    // salva na mdl_extensao_turma
+    $this->salvarTurmasExtensao($infos_turma);
+
+    /**
+     * Relacionar usuarios com turmas
+     * 
+     * eh preciso relacionar o NUSP dos usuarios com seus respectivos
+     * cursos, um array tipo:
+     * array(
+     *  'nusp' => ...,
+     *  'id_turma' => ...,
+     *  'role' => ... # nesse caso nessa importacao todos vao ser docentes
+     * )
+     * e ai vamos tambem salvar em uma tabela o seguinte array:
+     * array(
+     *  'id_turma' => ...,
+     *  'id_curso_apolo' => ...,
+     *  'nome_curso' => ... 
+     * )
+     * ai vamos poder relacionar as duas usando 'id_turma'.
+     */
+    
+    // monta o array que sera adicionado na mdl_extensao_usuario_curso
+    $infos_docentes_turmas = $this->filtrarInfosDocentesTurmas($turmas);
+    
+    // salva na mdl_extensao_usuario_curso
+    $this->salvarDocentesTurmas($infos_docentes_turmas);
+
+    // retorna a pagina de sincronizar
+    \core\notification::success('Atualizado com sucesso!');
+    $url = new moodle_url('/blocks/extensao/pages/sincronizar.php');
+    redirect($url);
+  }
+
+  // Filtra as infos das turmas, condensando somente algumas em outro array
+  private function filtrarInfosTurmas ($turmas) {
+    return array_map(function($turma) {
+      $obj = new stdClass;
+      $obj->id_turma_apolo = $turma['EdCurso']; // DUVIDA: eh essa info que queremos mesmo?
+      $obj->id_curso_apolo = $turma['codCursoExtensao'];
+      $obj->nome_curso_apolo = $turma['NomeCurso'];
+      return $obj;
+    }, $turmas);
+  }
+
+  // Fila as infos dos docentes e turmas, condensando somente algumas em outro array
+  private function filtrarInfosDocentesTurmas ($turmas) {
+    return array_map(function($turma) {
+      $obj = new stdClass;
+      $obj->id_turma_apolo = $turma['EdCurso']; // DUVIDA: eh essa info que queremos mesmo?
+      $obj->nusp_usuario = $turma['NUSP'];
+      $obj->papel_usuario = $turma['CodAtuacao'];
+      return $obj;
+    }, $turmas);
+  }
+
+  /**
+   * Procura as turmas na base para ver se ja constam
+   * 
+   * O que fazemos no caso de a turma ja constar?
+   * Ignorar ou substituir?
+   * 
+   * por enquanto esta sendo apenas ignorado
+   */
+  private function turmasNaBase ($turmas) {
+    global $DB;
+
+    $turmas_fora_base = array();
+
+    // percorre as turmas e vai procurando na base
+    foreach($turmas as $turma) {
+      // procura pela turma na base
+      $resultado_busca = $DB->record_exists('extensao_turma', array('id_turma_apolo' => $turma->id_turma_apolo));
+
+      // se existir, vamos apenas remover do $turmas...
+      if (!$resultado_busca)
+        $turmas_fora_base[] = $turma;
+    }
+    
+    return $turmas_fora_base;
+  }
+
+  // Salvar as turmas de extensao
+  private function salvarTurmasExtensao ($cursos_turmas) {
+    global $DB;
+    $DB->insert_records('extensao_turma', $cursos_turmas);
+  }    
+  
+  // Salvar as relacoes docente-turma
+  private function salvarDocentesTurmas ($docentes_turmas) {
+    global $DB;
+    $DB->insert_records('extensao_usuario_turma', $docentes_turmas);
+  }
+
+}
+
+$sinc = new Sincronizar();

--- a/templates/extensao_block.mustache
+++ b/templates/extensao_block.mustache
@@ -1,0 +1,3 @@
+<p>Sincronizar os cursos com o Apolo</p>
+
+<a class="btn btn-primary" href="{{ urlPaginaSincronizar }}">Sincronizar</a>

--- a/templates/sincronizar.mustache
+++ b/templates/sincronizar.mustache
@@ -1,0 +1,4 @@
+<h2>Sincronização</h2>
+
+<a class="btn btn-primary" href="{{ urlSincronizar }}"> Sincronizar </a>
+<a class="btn btn-danger" href="{{ urlCancelar }}"> Cancelar </a>


### PR DESCRIPTION
Adicionadas funções e uma interface para a sincronização manual dos cursos com o Apolo. Um botão em uma view chama a função de sincronização, e esta verifica turma a turma se já consta na base; constando, apenas ignora, mas se não constar então adiciona.

A query para a consulta no Apolo está em src/Service/Query.php. A sincronização é feita pela class Sincronizar em src/sincronizar.php.

A partir da Issue #4 : 

- [x] Criar as tabelas locais para a sincronização de cursos e usuários do Apolo localmente no moodle [...];
- [X] Criar uma página dentro do plugin de sincronização (manual nesse momento);
- [ ] Mostrar o bloco com os botões das disciplinas que ainda não foram criados ambientes.