### PR TITLE
Sincronização do Apolo (issue #17).

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -18,6 +18,7 @@
         <FIELD NAME="nome_curso_apolo" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Nome do curso no Apolo."/>
         <FIELD NAME="id_moodle" TYPE="int" LENGTH="16" NOTNULL="false" SEQUENCE="false" COMMENT="Identificador do curso no Moodle"/>
         <FIELD NAME="data_importacao" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Data em que foi importada a turma."/>
+        <FIELD NAME="sincronizado_apolo" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" COMMENT="Indica se o curso foi sincronizado do Apolo (0 = Nao, 1 = Sim)"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="codofeatvceu"/>

--- a/src/Ambiente.php
+++ b/src/Ambiente.php
@@ -17,6 +17,8 @@ require_once(__DIR__ . '/Turmas.php');
 require_once(__DIR__ . '/Service/Query.php');
 require_once(__DIR__ . '/Usuario.php');
 require_once(__DIR__ . '/Atuacao.php');
+require_once(__DIR__ . '/Service/Sincronizacao.php');
+
 use block_extensao\Service\Query;
 
 class Ambiente {
@@ -65,6 +67,9 @@ class Ambiente {
     // se der certo, eh necessario salvar isso na base
     Turmas::atualizar_id_moodle_turma($info_forms->codofeatvceu, $moodle_curso->id);
     \core\notification::success('Ambiente criado com sucesso!');
+
+    // Por fim eh preenchido o campo sincronizado_apolo com 1 em relacao ao curso que foi criado
+    Sincronizar::sincronizadoApolo($moodle_curso->id);
 
     // inscreve o usuario logado no curso
     Usuario::inscreve_criador($moodle_curso->id);

--- a/src/Service/Sincronizacao.php
+++ b/src/Service/Sincronizacao.php
@@ -256,4 +256,32 @@ class Sincronizar {
     if ($parar) die($msg);
     else echo $msg;
   }
+
+  /**
+   * O objetivo dessa funcao eh verificar se o curso criado eh proveniente do sistema apolo,
+   * logo eh marcado na tabela block_extensao_turma, na coluna sincronizado_apolo, sim (1)
+   * para cursos sincronizados do apolo, e nao (0) para os que advindos de outra forma de criacao.
+   * 
+   * @param int $curso_id, que sinaliza o curso cujo id sera atualizado na tabela para indicar a sua criacao pelo plugin
+   * @return bool a funcao reponde sucesso ou fracasso caso ocorra algum erro  
+   */
+  public static function sincronizadoApolo($curso_id) {
+    global $DB;
+
+    // Defina a consulta SQL para atualizar o campo 'sincronizado_apolo' para 1.
+    $sql = "UPDATE {block_extensao_turma} SET sincronizado_apolo = 1 WHERE id_moodle = :curso_id";
+
+    // Parametros para a consulta SQL.
+    $params = array('curso_id' => $curso_id);
+
+    try {
+      // Execute a consulta SQL usando o metodo execute() do $DB.
+      $DB->execute($sql, $params); 
+      return true; // Indica que a atualizacao foi bem-sucedida.
+    } catch (Exception $e) {
+        // Em caso de erro, registre-o.
+        error_log("Erro ao atualizar 'sincronizado_apolo' para o curso ID: " . $curso_id . ". Erro: " . $e->getMessage());
+        return false; // Indica que houve um erro.
+    }
+  }
 }

--- a/version.php
+++ b/version.php
@@ -3,4 +3,4 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_extensao';
-$plugin->version = 2023090501;
+$plugin->version = 2024090401;


### PR DESCRIPTION
Foi criado no arquivo install.xml o campo sincronizado_apolo, sendo do tipo bool. Junto a isso foi criado dentro do arquivo Sincronização, a função sincronizadoApolo, quando um curso é criado a função atualiza automaticamente o campo sincronizado_apolo para 1, com isso podemos indentificar quais foram os cursos criados pelo plugin.