### PR TITLE
Bloqueio do acesso direto ao forms (#33)

### DIFF
--- a/pages/criar_ambiente.php
+++ b/pages/criar_ambiente.php
@@ -98,8 +98,9 @@ if (!empty($info_forms)) {
   // Caso contrario, salva
   $_SESSION['codofeatvceu'] = $codofeatvceu;
 }
-// Se estiver vazio, tenta pegar via sessao
-else $codofeatvceu = $_SESSION['codofeatvceu'];
+// Bloqueio do acesso direto
+else
+  redirect($CFG->wwwroot);
 
 // Verifica se a turma enviada eh do usuario logado
 if (!Turmas::usuario_docente_turma($USER->username, $codofeatvceu) && !Categorias::usuario_gerente_turma($USER->id, $codofeatvceu) ) {


### PR DESCRIPTION
A captura do $codofeatvceu é feita através do POST. Se o valor não estiver definido, então redireciona para a página inicial pois pode se tratar de uma tentativa de acesso direto.