### PR TITLE
Mudanças relativas a isseu #39.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -27,7 +27,7 @@ if ($ADMIN->fulltree) {
             <p>Esta é uma notificação da criação do ambiente virtual  em <strong>%data</strong>, do seu curso <strong>%curso</strong>, turma <strong>%turma</strong> na plataforma de 
             Cultura e Extensão da USP. Foi atribuído a você o papel de ministrante nesta plataforma pelo professor 
             <strong>%profTit</strong>. Para acessá-lo, clique no seguinte link:</p>
-            <p><a href=http://0.0.0.0:8888>Acessar o Ambiente Virtual</a></p>
+            <p><a href=https://cursosextensao.usp.br/dashboard/>Acessar o Ambiente Virtual</a></p>
             
             <p>Atenciosamente,</p>
             <p>Equipe Moodle USP Extensão</p>",

--- a/src/Usuario.php
+++ b/src/Usuario.php
@@ -207,11 +207,10 @@ class Usuario {
     }
 
     // Criando objeto do usuario
-    //
     $nomeCompleto = $usuario['nompes'];
-    $partesNome = explode(' ', $nomeCompleto); 
-    $primeiroNome = $partesNome[0];
-    $segundoNome = end($partesNome);
+    $partesNome = explode(" ", $nomeCompleto);
+    $primeiroNome = array_shift($partesNome);
+    $segundoNome = implode(" ", $partesNome); 
 
     $novoUsuario = new stdClass();
     $novoUsuario->username = (string) $usuario['codpes'];


### PR DESCRIPTION
Avaliei varias formas de conseguir adequar a inscrição de usúarios que possuem nome composto. Não consegui identificar nenhuma regra clara que fosse viavel a escolha do primeiro nome para nomes compostos. Logo, separei o 1º nome como Nome, e todo o restante como sobrenome. O moodle permite aos usúarios editarem esse tipo de informação, assim caso o usúario deseje, ele mesmo pode alterar essa parte.