### PR TITLE
Feature/periodo adicional

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -79,11 +79,39 @@ if ($ADMIN->fulltree) {
         '1' => '1 ano',
     );
     $setting = new admin_setting_configselect(
-    'block_extensao/periodo_curso',
-    'Selecione o período para pesquisa de cursos abertos. ', 
-    'Escolha o período desejado: ', 
-    '3',
-    $options
-);
+        'block_extensao/periodo_curso',
+        'Selecione o período para pesquisa de cursos abertos. ', 
+        'Escolha o período desejado: ', 
+        '3',
+        $options
+    );
     $settings->add($setting);
+
+    // Opcao de selecao do periodo adicional do final do curso
+    // O administrador do curso deve poder decidir o tempo adinal para o fim do curso
+
+    // Meses disponiveis
+    $options = array(
+        '1' => '1 mês',
+        '2' => '2 meses',
+        '3' => '3 meses',
+        '4' => '4 meses',
+        '5' => '5 meses',
+        '6' => '6 meses',
+        '7' => '7 meses',
+        '8' => '8 meses',
+        '9' => '9 meses',
+        '10' => '10 meses',
+        '11' => '11 meses',
+        '12' => '12 meses',
+    );
+    $setting = new admin_setting_configselect(
+        'block_extensao/periodoAdicional',
+        'Defina um periodo para prolongamento da data de finalização do curso.',
+        'Escolha o periodo:',
+        '2',
+        $options
+    );
+    $settings->add($setting);
+
 }

--- a/utils/forms.php
+++ b/utils/forms.php
@@ -83,7 +83,8 @@ class criar_ambiente_moodle extends moodleform {
 
     // data do fim do curso
     $end_date = $this->define_campo('enddate');
-    $end_date_timestamp = strtotime("+2 months", strtotime($end_date));
+    $data = get_config('block_extensao', 'periodoAdicional');
+    $end_date_timestamp = strtotime("+$data.months", strtotime($end_date));
     $this->_form->addElement('date_selector', 'enddate', 'Data do fim do curso');
     $this->_form->setDefault('enddate', $end_date_timestamp);
 
@@ -92,7 +93,7 @@ class criar_ambiente_moodle extends moodleform {
     $end_date_element = $this->_form->getElement('enddate');
     $end_date_element->setLabel('Data do fim do curso <span style="color: #ff0000; font-weight: bold;">' . $end_date_formatted . '</span>');
 
-    // Para definir o fim do curso 
+    // Para definir um estilo 
     $end_date_formatted = date('d/m/Y', $end_date_timestamp);
     $end_date_element = $this->_form->getElement('enddate');
     $end_date_element->setLabel('Data do fim do curso <span style="color: #ff0000; font-weight: bold;">' . $end_date_formatted . '</span>');

--- a/utils/forms.php
+++ b/utils/forms.php
@@ -84,7 +84,7 @@ class criar_ambiente_moodle extends moodleform {
     // data do fim do curso
     $end_date = $this->define_campo('enddate');
     $data = get_config('block_extensao', 'periodoAdicional');
-    $end_date_timestamp = strtotime("+$data.months", strtotime($end_date));
+    $end_date_timestamp = strtotime("+$data months", strtotime($end_date));
     $this->_form->addElement('date_selector', 'enddate', 'Data do fim do curso');
     $this->_form->setDefault('enddate', $end_date_timestamp);
 

--- a/utils/forms.php
+++ b/utils/forms.php
@@ -76,6 +76,11 @@ class criar_ambiente_moodle extends moodleform {
     $this->_form->setDefault('fullname', "{$fullname} ({$ano_curso})");
     $this->_form->setType('fullname', PARAM_TEXT);
 
+    // data de inicio do curso
+    $init_date_timestamp = strtotime($init_date);
+    $this->_form->addElement('date_selector', 'startdate', 'Data de início do curso');
+    $this->_form->setDefault('startdate', $init_date_timestamp);
+
     // data do fim do curso
     $end_date = $this->define_campo('enddate');
     $end_date_timestamp = strtotime("+2 months", strtotime($end_date));

--- a/version.php
+++ b/version.php
@@ -3,4 +3,4 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_extensao';
-$plugin->version = 2024022602;
+$plugin->version = 2024050202;


### PR DESCRIPTION
Foi alterado o plugin de forma que agora o usuário administrador consegue na base do plugin definir o período adicionado para a finalização do curso da plataforma a partir da data de final do curso. As opções permitem que ele escolha de 1 à 12 meses.