### PR TITLE
Definição do e-mail ideal - Issue #40

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -27,7 +27,7 @@ if ($ADMIN->fulltree) {
             <p>Esta é uma notificação da criação do ambiente virtual  em <strong>%data</strong>, do seu curso <strong>%curso</strong>, turma <strong>%turma</strong> na plataforma de 
             Cultura e Extensão da USP. Foi atribuído a você o papel de ministrante nesta plataforma pelo professor 
             <strong>%profTit</strong>. Para acessá-lo, clique no seguinte link:</p>
-            <p><a href=http://0.0.0.0:8888>Acessar o Ambiente Virtual</a></p>
+            <p><a href=https://cursosextensao.usp.br/dashboard/>Acessar o Ambiente Virtual</a></p>
             
             <p>Atenciosamente,</p>
             <p>Equipe Moodle USP Extensão</p>",

--- a/src/Service/Query.php
+++ b/src/Service/Query.php
@@ -44,7 +44,6 @@ class Query
    * data de encerramento posterior a data de hoje.
    */
 
-  
   public function turmasAbertas () {
     
     $periodo = get_config('block_extensao', 'periodo_curso');
@@ -83,10 +82,8 @@ class Query
       WHERE e.dtainiofeedi >= '$inicio_curso'
       ORDER BY codofeatvceu 
     ";
-
     return USPDatabase::fetchAll($query);
   }
-
 
   /**
    * Captura os ministrantes das turmas informadas.
@@ -110,26 +107,26 @@ class Query
     $turmas = implode(', ', $codofeatvceu_turmas);
     $hoje = date("Y-m-d");
     $query = "
-        SELECT
-            m.codofeatvceu,
-            m.codpes,
-            m.codatc,
-            COALESCE(email_preferencial.codema, email_disponivel.codema) AS codema
-        FROM 
-        " . $this->MINISTRANTECEU . "  m
-        LEFT JOIN 
-            (SELECT codpes, codema FROM  " . $this->EMAILPESSOA . "  WHERE stamtr = 'S') AS email_preferencial 
-            ON m.codpes = email_preferencial.codpes
-        LEFT JOIN 
-            (SELECT codpes, codema FROM  " . $this->EMAILPESSOA . " ) AS email_disponivel 
-            ON m.codpes = email_disponivel.codpes
-        WHERE 
-            m.codpes IS NOT NULL
-            AND m.codofeatvceu IN ($turmas)
-            AND m.dtainimisatv >= '$hoje'
-        ORDER BY 
-            codofeatvceu  
-    ";
+      SELECT
+        m.codofeatvceu,
+        m.codpes,
+        m.codatc,
+        COALESCE(email_preferencial.codema, email_disponivel.codema) AS codema
+      FROM 
+      " . $this->MINISTRANTECEU . "  m
+      LEFT JOIN 
+        (SELECT codpes, codema FROM  " . $this->EMAILPESSOA . "  WHERE stamtr = 'S') AS email_preferencial 
+        ON m.codpes = email_preferencial.codpes
+      LEFT JOIN 
+        (SELECT codpes, codema FROM  " . $this->EMAILPESSOA . " ) AS email_disponivel 
+        ON m.codpes = email_disponivel.codpes
+      WHERE 
+        m.codpes IS NOT NULL
+        AND m.codofeatvceu IN ($turmas)
+        AND m.dtainimisatv >= '$hoje'
+      ORDER BY 
+        codofeatvceu  
+  ";
     return USPDatabase::fetchAll($query);
   }
 

--- a/src/Service/Query.php
+++ b/src/Service/Query.php
@@ -110,17 +110,25 @@ class Query
     $turmas = implode(', ', $codofeatvceu_turmas);
     $hoje = date("Y-m-d");
     $query = "
-      SELECT
-        m.codofeatvceu,
-        m.codpes,
-        m.codatc,
-        e.codema
-      FROM " . $this->MINISTRANTECEU . " m
-      LEFT JOIN " . $this->EMAILPESSOA . " e ON m.codpes = e.codpes
-      WHERE m.codpes IS NOT NULL
-        AND m.codofeatvceu IN ($turmas)
-        AND m.dtainimisatv >= '$hoje'
-      ORDER BY m.codofeatvceu
+        SELECT
+            m.codofeatvceu,
+            m.codpes,
+            m.codatc,
+            COALESCE(email_preferencial.codema, email_disponivel.codema) AS codema
+        FROM 
+        " . $this->MINISTRANTECEU . "  m
+        LEFT JOIN 
+            (SELECT codpes, codema FROM  " . $this->EMAILPESSOA . "  WHERE stamtr = 'S') AS email_preferencial 
+            ON m.codpes = email_preferencial.codpes
+        LEFT JOIN 
+            (SELECT codpes, codema FROM  " . $this->EMAILPESSOA . " ) AS email_disponivel 
+            ON m.codpes = email_disponivel.codpes
+        WHERE 
+            m.codpes IS NOT NULL
+            AND m.codofeatvceu IN ($turmas)
+            AND m.dtainimisatv >= '$hoje'
+        ORDER BY 
+            codofeatvceu  
     ";
     return USPDatabase::fetchAll($query);
   }

--- a/version.php
+++ b/version.php
@@ -3,4 +3,4 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_extensao';
-$plugin->version = 2024022602;
+$plugin->version = 2024050202;


### PR DESCRIPTION
Foi modificada a query que obtêm o e-mail do usuário, antes era captado um e-mail aleatório dentro da base de dados, agora é selecionado o e-mail cujo usuário definiu como sendo o preferencial,de modo que ele tem a coluna "stamtr" marcada com um "S". Caso o usuário não tenha definido nenhum e-mail como preferencial, o endereço que está disponível na pagina é captado. Foram realizados teste, e uma amostra foi analisada confirmando que a nova query funciona.