### PR TITLE
Correções e refatoração da sincronização (#45)

### DIFF
--- a/cli/sync.php
+++ b/cli/sync.php
@@ -50,7 +50,7 @@ list($opcoes, $nao_reconhecidas) = cli_get_params([
 ], [
   'h' => 'help'
 ]);
-echo 'oie';
+
 // tratamento de parametros informados que sao desconhecidos
 if ($nao_reconhecidas) {
   $nao_reconhecidas = implode(PHP_EOL . '  ', $nao_reconhecidas);

--- a/cli/sync.php
+++ b/cli/sync.php
@@ -38,7 +38,9 @@ Uso:
 
 Opcoes:
   -h --help              Exibe essa ajuda.
-  --pular_ministrantes   Nao sincroniza os ministrantes.
+  --pular_ministrantes   Nao atualiza ministrantes para cursos que ja
+                         estavam na base. Novos cursos terao todos os
+                         ministrantes inseridos.
 ";
 
 // opcoes
@@ -48,7 +50,7 @@ list($opcoes, $nao_reconhecidas) = cli_get_params([
 ], [
   'h' => 'help'
 ]);
-
+echo 'oie';
 // tratamento de parametros informados que sao desconhecidos
 if ($nao_reconhecidas) {
   $nao_reconhecidas = implode(PHP_EOL . '  ', $nao_reconhecidas);

--- a/src/Service/Query.php
+++ b/src/Service/Query.php
@@ -52,21 +52,12 @@ class Query
 
     // opcoes para a pesquisa do inicio da busca por curso, coloquei as opcoes de 3, 6, 9 meses 
     // e 1 ano, no entanto, esse valor pode ser alterado caso seja pertinente.
+    if (in_array($periodo, ["3", "6", "9"]))
+      $periodo_str = "-$periodo months";
+    else
+      $periodo_str = "-1 year";
+    $inicio_curso = date("Y-m-d", strtotime($periodo_str, strtotime($diaAtual)));
 
-    if($periodo == "3"){
-        $inicio_curso =  date("Y-m-d", strtotime("-3 months", strtotime($diaAtual)));
-    } elseif ($periodo == "6") {
-        $inicio_curso = date("Y-m-d", strtotime("-6 months", strtotime($diaAtual)));
-    } elseif ($periodo == "9") {
-        $inicio_curso = date("Y-m-d", strtotime("-9 months", strtotime($diaAtual)));
-    } elseif ($periodo == "1") {
-      $inicio_curso = date("Y-m-d", strtotime("-1 year", strtotime($diaAtual)));
-    } else { 
-      // caso nenhum periodo seja definido, o sistema inicia a busca de cursos com a data de inicio
-      // posterior a 1 ano. 
-      $inicio_curso = date("Y-m-d", strtotime("-1 year", strtotime($diaAtual)));
-    }
-   
     $query = "
       SELECT
         o.codofeatvceu
@@ -108,7 +99,6 @@ class Query
    */
   public function ministrantesTurmas ($codofeatvceu_turmas) {
     $turmas = implode(', ', $codofeatvceu_turmas);
-    $hoje = date("Y-m-d");
     $query = "
       SELECT
         m.codofeatvceu,
@@ -119,7 +109,6 @@ class Query
       LEFT JOIN " . $this->EMAILPESSOA . " e ON m.codpes = e.codpes
       WHERE m.codpes IS NOT NULL
         AND m.codofeatvceu IN ($turmas)
-        AND m.dtainimisatv >= '$hoje'
       ORDER BY m.codofeatvceu
     ";
     return USPDatabase::fetchAll($query);

--- a/src/Service/Sincronizacao.php
+++ b/src/Service/Sincronizacao.php
@@ -18,235 +18,9 @@ use core\notification;
 class Sincronizar {
 
   /**
-   * Apenas para nao inicializar com o metodo homonimo.
+   * Apenas para nao inicializar com o metodo homonimo
    */
   public function __construct() {}
-
-  /**
-   * Tenta conectar na base do Apolo para ver se as
-   * credenciais foram informadas e se estao corretas.
-   * 
-   * @return bool 
-   */
-  private function conexao_apolo () {
-    return (new Query())->testar_conexao();
-  }
-
-  /**
-   * Sincronizacao dos dados entre Apolo e Moodle
-   * 
-   * @param bool $apagar Para apagar os dados atuais antes de sincronizar
-   */
-  public function sincronizar ($parametros) {
-    // Verifica se as credenciais da base foram passadas
-    $this->conexao_apolo();
-
-    cli_writeln(PHP_EOL."/*********************************/");
-    cli_writeln("/    SINCRONIZACAO COM O APOLO    /");
-    cli_writeln("/*********************************/");
-
-    // Sincronizando as turmas
-    $turmas = $this->sincronizarTurmas();
-    // Se $turmas for false, eh que a base ja esta sincronizada
-    if (!$turmas) return;
-  
-    if (!$parametros['pular_ministrantes']) {
-      // Sincronizando os ministrantes
-      $this->sincronizarMinistrantes(array_keys($turmas));
-    }
-
-    // Retorna a pagina de sincronizar
-    cli_writeln(PHP_EOL . "Atualizado com sucesso!");
-
-    cli_writeln(PHP_EOL."/*********************************/");
-    cli_writeln("/     SINCRONIZACAO CONCLUIDA     /");
-    cli_writeln("/*********************************/");
-  }
-
-  /**
-   * Sincronizacao das turmas
-   * 
-   * @return array|bool
-   */
-  private function sincronizarTurmas () {
-    cli_writeln(PHP_EOL . '[TURMAS]' . PHP_EOL . '# Capturando turmas...');
-
-    // Captura as turmas
-    $turmas = (new Query())->turmasAbertas();
-
-    // Se der erro na busca, ja para por aqui
-    if (!$turmas) die(PHP_EOL);
-
-    // Monta o array que sera adicionado na mdl_extensao_turma
-    $infos_turma = $this->objetoTurmas($turmas);
-
-    // Pega as turmas que nao estao na base
-    $infos_turma = $this->turmasNaBase($infos_turma);
-
-    // Se estiver vazio nao tem por que continuar
-    if (empty($infos_turma)) {
-      cli_writeln('(X) A base já estava sincronizada!');
-      return false;
-    }
-
-    try {
-      cli_writeln('* Foram encontradas ' . count($infos_turma) . ' turmas!');
-      // Salva na mdl_extensao_turma
-      cli_writeln('# Salvando turmas...');
-      $this->salvarTurmasExtensao($infos_turma);
-      cli_writeln('* Turmas sincronizadas!');
-      return $infos_turma;
-    } catch (Exception $e) {
-      $this->mensagemErro('ERRO AO SINCRONIZAR AS TURMAS:', $e, true);
-    }
-  }
-
-  /**
-   * Sincronizacao dos ministrantes a partir das turmas informadas.
-   * Os ministrantes das turmas informadas sao listados e adicionados
-   * a tabela block_extensao_ministrante. 
-   * 
-   * @param array $turmas Lista de codofeatvceus.
-   * @return bool Se deu certo ou nao.
-   */
-  private function sincronizarMinistrantes ($turmas) {
-    cli_writeln(PHP_EOL . '[MINISTRANTES]' . PHP_EOL . '# Capturando ministrantes...');
-    // Captura os ministrantes
-    $ministrantes = (new Query())->ministrantesTurmas($turmas);
-    // Indexa o array de ministrantes, para evitar as duplicatas do e-mail
-    $ministrantes = $this->removerDuplicatasMinistrantes($ministrantes);
-
-    if (!$ministrantes) {
-      cli_writeln('* [PROVAVEL ERRO] Nenhum ministrante encontrado');
-    }
-    cli_writeln('* Foram encontrados ' . count($ministrantes) . ' ministrantes!');
-
-    // Monta o array que sera adicionado na mdl_extensao_ministrante
-    cli_writeln('# Criando objetos...');
-    $ministrantes = $this->objetoMinistrantes($ministrantes);
-    
-    // Salva na mdl_extensao_ministrante
-    try {
-      cli_writeln('# Salvando ministrantes...');
-      $this->salvarMinistrantesTurmas($ministrantes);
-      cli_writeln('* Ministrantes sincronizados!');
-      return true;
-    } catch (Exception $e) {
-      $this->mensagemErro('ERRO AO SINCRONIZAR OS MINISTRANTES:', $e, true);
-    }
-  }
-
-  /**
-   * Gera um indice unico a partir do codpes e do codofeatvceu para
-   * eliminar duplicatas (oriundas do 'left join' com a tabela de
-   * e-mails).
-   * 
-   * @param array $ministrantes Lista de ministrantes obtidas do Apolo.
-   * @return array Lista filtrada e indexada.
-   */
-  private function removerDuplicatasMinistrantes ($ministrantes) {
-    $lista = array();
-    foreach ($ministrantes as $ministrante) {
-      $indice = $ministrante['codpes'] . "_" . $ministrante['codofeatvceu'];
-      if (!array_key_exists($indice, $lista))
-        $lista[$indice] = $ministrante;
-    }
-    return $lista;
-  }
-
-  /**
-   * Filtra as infos das turmas, condensando somente algumas em 
-   * outro array
-   * 
-   * @param array $turmas Lista de turmas
-   * 
-   * @return array
-   */
-  private function objetoTurmas ($turmas) {
-    return array_map(function($turma) {
-      $obj = new stdClass;
-      $obj->codofeatvceu = $turma['codofeatvceu'];
-      $obj->nome_curso_apolo = $turma['nomcurceu'];
-      $obj->codund = $turma['codund'];
-      $obj->codcam = $turma['codcam'];
-      return $obj;
-    }, $turmas);
-  }
-
-  /**
-   * Cria objetos para os arrays
-   * 
-   * @param array $ministrantes Lista de ministrantes
-   * 
-   * @return array
-   */ 
-  private function objetoMinistrantes ($ministrantes) {
-    return array_map(function($ministrante) {
-      $obj = new stdClass;
-      $obj->codofeatvceu = $ministrante['codofeatvceu'];
-      $obj->codpes = $ministrante['codpes'];
-      $obj->papel_usuario = $ministrante['codatc'];
-      return $obj;
-    }, $ministrantes);
-  }
-
-  /**
-   * Procura as turmas na base para ver se ja constam
-   * O que fazemos no caso de a turma ja constar?
-   * Ignorar ou substituir? por enquanto esta sendo 
-   * apenas ignorado
-   * 
-   * @param array $turmas Lista de turmas
-   * 
-   * @return array
-   */
-  private function turmasNaBase ($turmas) {
-    global $DB;
-
-    $turmas_fora_base = array();
-
-    // Percorre as turmas e vai procurando na base
-    foreach($turmas as $turma) {
-      // Procura pela turma na base
-      $resultado_busca = $DB->get_record('block_extensao_turma', array('codofeatvceu' => $turma->codofeatvceu));
-
-      // Se nao existir ou se o campo 'id_moodle' for NULL, adiciona na lista
-      if (!$resultado_busca)
-        $turmas_fora_base[$turma->codofeatvceu] = $turma;
-      else if (is_null($resultado_busca->id_moodle)) {
-        // Se o ambiente nao existir, entao apaga os registros para adicionar novamente
-        $DB->delete_records('block_extensao_turma', array('codofeatvceu' => $turma->codofeatvceu));
-        $DB->delete_records('block_extensao_ministrante', array('codofeatvceu' => $turma->codofeatvceu));
-        $turmas_fora_base[$turma->codofeatvceu] = $turma;
-      }
-
-      // Data de importacao
-      date_default_timezone_set('America/Sao_Paulo');
-      $turma->data_importacao = time();
-    }
-    
-    return $turmas_fora_base;
-  }
-
-  /**
-   * Para salvar as turmas de extensao.
-   * 
-   * @param array $cursos_turmas Turmas dos cursos.
-   */
-  private function salvarTurmasExtensao ($cursos_turmas) {
-    global $DB;
-    $DB->insert_records('block_extensao_turma', $cursos_turmas);
-  }    
-  
-  /**
-   * Para salvar as relacoes entre ministrante e turma
-   * 
-   * @param array $ministrantes Lista de ministrantes
-   */
-  private function salvarMinistrantesTurmas ($ministrantes) {
-    global $DB;
-    $DB->insert_records('block_extensao_ministrante', $ministrantes);
-  }
 
   /**
    * Para exibir mensagens de erro.
@@ -261,31 +35,283 @@ class Sincronizar {
   }
 
   /**
-   * O objetivo dessa funcao eh verificar se o curso criado eh proveniente do sistema apolo,
-   * logo eh marcado na tabela block_extensao_turma, na coluna sincronizado_apolo, sim (1)
-   * para cursos sincronizados do apolo, e nao (0) para os que advindos de outra forma de criacao.
+   * Tenta conectar na base do Apolo para ver se as credenciais
+   * foram informadas e se estao corretas.
    * 
-   * @param int $curso_id, que sinaliza o curso cujo id sera atualizado na tabela para indicar a sua criacao pelo plugin
-   * @return bool a funcao reponde sucesso ou fracasso caso ocorra algum erro  
+   * @return bool
    */
-  public static function sincronizadoApolo($curso_id) {
-    global $DB;
+  private function conexao_apolo () {
+    return (new Query())->testar_conexao();
+  }
 
-    // Defina a consulta SQL para atualizar o campo 'sincronizado_apolo' para 1.
-    $sql = "UPDATE {block_extensao_turma} SET sincronizado_apolo = 1 WHERE id_moodle = :curso_id";
+  /**
+   * Sincronizacao dos dados entre Apolo e Moodle
+   * 
+   * @param array $parametros Parametros para a sincronizacao
+   * @return bool
+   */
+  public function sincronizar (array $parametros) {
+    cli_writeln(PHP_EOL."/*********************************/");
+    cli_writeln("/*********************************/");
 
-    // Parametros para a consulta SQL.
-    $params = array('curso_id' => $curso_id);
-
-    try {
-      // Execute a consulta SQL usando o metodo execute() do $DB.
-      $DB->execute($sql, $params);
-
-      return true; // Indica que a atualizacao foi bem-sucedida.
-    } catch (Exception $e) {
-        // Em caso de erro, registre-o.
-        error_log("Erro ao atualizar 'sincronizado_apolo' para o curso ID: " . $curso_id . ". Erro: " . $e->getMessage());
-        return false; // Indica que houve um erro.
+    cli_writeln("/    SINCRONIZACAO COM O APOLO    /");
+    // Verifica se as credenciais da base foram passadas
+    $conexao = $this->conexao_apolo();
+    if ($conexao) {
+      cli_writeln(PHP_EOL."Conectado com o Apolo.");
+    } else {
+      cli_writeln(PHP_EOL."ERRO FATAL: Erro na conexão com o Apolo!");
+      cli_writeln(PHP_EOL."Por favor, verifique se os dados de autenticação com a base estao corretos."); 
+      cli_writeln(PHP_EOL."Abortando sincronizacao");
+      return FALSE;
     }
+
+    // Parametros
+    $atualizar_ministrantes = !$parametros['pular_ministrantes'];
+
+    // Sincronizando as turmas
+    // A variavel $turmas contem todas as turmas que foram adicionadas
+    // ou atualizadas na sincronizacao
+    $turmas_retorno = $this->sincronizarTurmas($remover_ministrantes=$atualizar_ministrantes);
+    
+    // Sincronizando os ministrantes
+    // A sincronizacao dos ministrantes ocorre a depender da escolha de
+    // atualizar ministrantes ja cadastrados na base ou nao. Em ambos
+    // os casos, porem, se alguma turma for nova na base, seus ministrantes
+    // serao adicionados
+    // As chaves do $turmas_retorno sao os codofeatvceu
+    // Se nao tiver turmas novas e nao for atualizar, nao precisa rodar
+    if (empty($turmas_retorno) && !$atualizar_ministrantes) {
+      cli_writeln(PHP_EOL."Nenhuma turma nova! Os ministrantes nao serao atualizados.");
+    } else if (!empty($turmas_retorno)) {
+      $this->sincronizarMinistrantes(array_keys($turmas_retorno), $atualizar_ministrantes);
+    } else {
+      cli_writeln(PHP_EOL."Nenhuma turma encontrada!");
+    }
+
+    cli_writeln(PHP_EOL."Atualizado com sucesso!");
+    cli_writeln(PHP_EOL."/*********************************/");
+    cli_writeln("/     SINCRONIZACAO CONCLUIDA     /");
+    cli_writeln("/*********************************/");
+  }
+
+  /**
+   * Sincronizacao das turmas
+   * 
+   * Captura no Apolo as turmas abertas no periodo pre-configurado. As
+   * turmas sao entao transformadas em objetos inseriveis no banco de
+   * dados, as turmas antigas que ainda nao tenham ambiente Moodle sao
+   * deletadas e todas sao inseridas de uma vez.
+   * 
+   * @param bool $remover_ministrantes Se deseja deletar os ministrantes
+   *                                   junto das turmas sem ambiente.
+   * @return array Turmas capturadas e turmas removidas da base
+   */
+  private function sincronizarTurmas ($remover_ministrantes=TRUE) {
+    // Captura das turmas no Apolo
+    cli_writeln(PHP_EOL."[TURMAS]".PHP_EOL."# Capturando turmas...");
+    $turmas = (new Query())->turmasAbertas();
+    cli_writeln('* Foram encontradas ' . count($turmas) . ' turmas!');
+
+    // Se nenhuma turma for encontrada, encerra a sincronizacao
+    if (!$turmas) {
+      cli_writeln(PHP_EOL."[TURMAS]".PHP_EOL."! Nenhuma turma encontrada!");
+      return $turmas; // = [];
+    }
+
+    // Monta o array que sera adicionado na mdl_extensao_turma
+    cli_writeln('# Montando objetos...');
+    $objetos_turmas = $this->objetoTurmas($turmas);
+
+    // Remove as turmas encontradas que ja estao na base e que ainda nao tiveram seu
+    // ambiente Moodle criado
+    cli_writeln('# Removendo turmas sem ambiente da base local...');
+    $turmas_novas = $this->removerTurmasSemAmbiente($objetos_turmas, $remover_ministrantes);
+
+    // Agora adiciona todas as turmas
+    cli_writeln("# Salvando turmas...");
+    try {
+      $this->salvarTurmasExtensao($objetos_turmas);
+      cli_writeln("* Turmas sincronizadas!");
+      // Se tiver removido os ministrantes, precisa retornar todas as turmas
+      if ($remover_ministrantes)
+        return $objetos_turmas;
+      // Se nao, retorna so as novas
+      else
+        return $turmas_novas;
+    } catch (Exception $e) {
+      // Mensagem de erro e die()
+      $this->mensagemErro("ERRO AO SINCRONIZAR AS TURMAS:", $e->getMessage(), true);
+    }
+  }
+
+  /**
+   * Objeto de turmas
+   * 
+   * Cria um array de objetos com as turmas, no padrao exigido pelo
+   * Moodle para inserir as informacoes na base.
+   * 
+   * @param array $turmas Array com as turmas capturadas no Apolo
+   * @return array 
+   */
+  private function objetoTurmas (array $turmas) {
+    date_default_timezone_set('America/Sao_Paulo');
+    $turmas_objetos = array();
+    foreach ($turmas as $turma) {
+      $obj = new stdClass;
+      $obj->codofeatvceu = $turma['codofeatvceu'];
+      $obj->nome_curso_apolo = $turma['nomcurceu'];
+      $obj->codund = $turma['codund'];
+      $obj->codcam = $turma['codcam'];
+      $obj->data_importacao = time(); // Data de importacao
+      $turmas_objetos[$obj->codofeatvceu] = $obj;
+    }
+    return $turmas_objetos;
+  }
+
+  /**
+   * Remocao de turmas sem ambiente
+   * 
+   * Dado um array de objetos de turmas, cada turma que constar na tabela de turmas
+   * do plugin mas nao tiver um ambiente criado associado (i.e., `id_moodle=NULL`).
+   * Somente as turmas no array informado serao verificadas.
+   * 
+   * O array informado deve ser uma lista de objetos de turmas, e cada objeto deve
+   * ter a propriedade `codofeatvceu` (codigo de oferecimento).
+   * 
+   * @param array $turmas Array com as turmas 
+   * @param bool $remover_ministrantes Se deseja remover os ministrantes tambem
+   * @return array $turmas_novas Turmas que nao estavam na base
+   */
+  private function removerTurmasSemAmbiente(array $turmas, bool $remover_ministrantes) {
+    global $DB;
+    $turmas_novas = array();
+    // Percorre a lista de turmas e vai procurando cada uma
+    foreach ($turmas as $turma) {
+      // Procura pela turma na base
+      $query_where = array('codofeatvceu'=>$turma->codofeatvceu);
+      $resultado_busca = $DB->get_record('block_extensao_turma', $query_where);
+
+      // Se nao estiver na base, segue 
+      if (!$resultado_busca) {
+        $turmas_novas[$turma->codofeatvceu] = $turma;
+        continue;
+      } 
+      
+      // Se o campo `id_moodle` for NULL, remove
+      else if (is_null($resultado_busca->id_moodle)) {
+        // Apaga os registros
+        $DB->delete_records('block_extensao_turma', $query_where);
+        // Se quiser apagar os ministrantes tambem
+        if ($remover_ministrantes) {
+          $DB->delete_records('block_extensao_ministrante', $query_where);
+        }
+      }
+    }
+    return $turmas_novas;
+  }
+
+  /**
+   * Para salvar as turmas no Moodle
+   * 
+   * @param array $turmas Lista de turmas
+   * @return null
+   */
+  private function salvarTurmasExtensao (array $turmas) {
+    global $DB;
+    $DB->insert_records('block_extensao_turma', $turmas);
+  }
+
+  /**
+   * Sincronizacao dos ministrantes
+   * 
+   * A partir das turmas capturadas na sincronizacao de turmas, captura os ministrantes
+   * respectivos de cada turma, adapta ao formato exigido pelo Moodle e insere na base
+   * de dados local.
+   * 
+   * Se `$atualizar_ministrantes=TRUE`, os ministrantes que ja estao na base e cujas turmas
+   * associadas foram capturadas serao removidos e readicionados, se nao apenas os
+   * ministrantes de turmas novas serao adicionados. Essa possibilidade foi adicionada
+   * tendo em vista que eventualmente professores novos sao cadastrados em turmas ou mesmo
+   * removidos no Apolo. A sincronizacao com atualizacao garantira que o sistema esta
+   * sincronizado com o Apolo
+   * 
+   * @param array $turmas Lista de turmas capturadas no Apolo (objetos)
+   * @param bool  $atualizar_ministrantes Se deseja atualizar os ministrantes ja existentes.
+   * @return bool
+   */
+  private function sincronizarMinistrantes (array $turmas, bool $atualizar_ministrantes) {
+    // Captura dos ministrantes no Apolo
+    cli_writeln(PHP_EOL."[MINISTRANTES]".PHP_EOL."# Capturando ministrantes...");
+    $ministrantes = (new Query())->ministrantesTurmas($turmas);
+    // Indexa o array de ministrantes, para evitar as duplicatadas do e-mail
+    $ministrantes = $this->removerMinistrantesDuplicados($ministrantes);
+
+    if (!$ministrantes) {
+      cli_writeln("* [PROVAVEL ERRO] Nenhum ministrante encontrado!");
+    }
+    cli_writeln('* Foram encontrados ' . count($ministrantes) . ' ministrantes!');
+
+    // Monta o array que sera adicionado na block_extensao_ministrante
+    cli_writeln('# Montando objetos...');
+    $ministrantes = $this->objetoMinistrantes($ministrantes);
+
+    // Salvando dados dos ministrantes
+    cli_writeln("# Salvando ministrantes...");
+    try {
+      $this->salvarMinistrantes($ministrantes);
+      cli_writeln("* Ministrantes sincronizados!");
+      return TRUE;
+    } catch (Exception $e) {
+      // Mensagem de erro e die()
+      $this->mensagemErro("ERRO AO SINCRONIZAR OS MINISTRANTES: ", $e->getMessage(), true);
+    }
+  }
+
+  /**
+   * Gera um indice unico a partir do codpes e do codofeatvceu para  eliminar duplicatas
+   * (oriundas do `left join` com a tabela de e-mails).
+   * 
+   * @param array $ministrantes Lista de ministrantes obtidas do Apolo
+   * @return array Lista filtrada e indexada
+   */
+  private function removerMinistrantesDuplicados (array $ministrantes) {
+    $lista = array();
+    foreach ($ministrantes as $ministrante) {
+      $indice = $ministrante['codpes'] . "_" . $ministrante['codofeatvceu'];
+      if (!array_key_exists($indice, $lista))
+        $lista[$indice] = $ministrante;
+    }
+    return $lista;
+  }
+
+  /**
+   * Objeto de ministrantes
+   * 
+   * Cria um array de objetos com os ministrantes, no padrao exigido pelo
+   * Moodle para inserir as informacoes na base.
+   * 
+   * @param array $ministrantes Array com os ministrantes capturadas no Apolo
+   * @return array 
+   */
+  private function objetoMinistrantes (array $ministrantes) {
+    return array_map(function($ministrante) {
+      $obj = new stdClass;
+      $obj->codofeatvceu = $ministrante['codofeatvceu'];
+      $obj->codpes = $ministrante['codpes'];
+      $obj->papel_usuario = $ministrante['codatc'];
+      return $obj;
+    }, $ministrantes);
+  }
+
+  /**
+   * Para salvar as relacoes entre ministrante e turma
+   * 
+   * @param array $ministrantes Lista de ministrantes
+   * @return null
+   */
+  private function salvarMinistrantes (array $ministrantes) {
+    global $DB;
+    $DB->insert_records('block_extensao_ministrante', $ministrantes);
   }
 }

--- a/src/Service/Sincronizacao.php
+++ b/src/Service/Sincronizacao.php
@@ -52,9 +52,9 @@ class Sincronizar {
    */
   public function sincronizar (array $parametros) {
     cli_writeln(PHP_EOL."/*********************************/");
+    cli_writeln("/    SINCRONIZACAO COM O APOLO    /");    
     cli_writeln("/*********************************/");
-
-    cli_writeln("/    SINCRONIZACAO COM O APOLO    /");
+    
     // Verifica se as credenciais da base foram passadas
     $conexao = $this->conexao_apolo();
     if ($conexao) {


### PR DESCRIPTION
- O arquivo "Sincronizacao.php" foi refatorado e melhor documentado;
- O problema apresentado na issue #45 foi resolvido da seguinte maneira: quando a opção --pular_ministrantes for passada, os ministrantes que ja estiverem na base serao ignorados, e somente se houver alguma turma que nao estava na base antes, ai sim terá seus ministrantes adicionados. Isso significa que na ausência de tal opção, todos os ministrantes são removidos e reinseridos.
- O "Query.php" estava com um erro lógico na busca por ministrantes, utilizando-se da data atual em vez da data da turma para encontrar os ministrantes.