### PR TITLE
Adição do número de sequência de oferecimento - Issue #41

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -54,6 +54,10 @@ if ($ADMIN->fulltree) {
     // Campo para a tabela de "MINISTRANTECEU"
     $setting = new admin_setting_configtext('block_extensao/tabela_ministranteceu', 'MINISTRANTECEU', '', 'MINISTRANTECEU', PARAM_TEXT);
     $settings->add($setting);
+
+    // Campo para a tabela de "ATUACAOCEU"
+    $setting = new admin_setting_configtext('block_extensao/tabela_atuacaoceu', 'ATUACAOCEU', '', 'ATUACAOCEU', PARAM_TEXT);
+    $settings->add($setting);
     
     // Campo para a tabela de "EMAILPESSOA"
     $setting = new admin_setting_configtext('block_extensao/tabela_emailpessoa', 'EMAILPESSOA', '', 'EMAILPESSOA', PARAM_TEXT);

--- a/src/Ambiente.php
+++ b/src/Ambiente.php
@@ -79,6 +79,9 @@ class Ambiente {
     Usuario::inscreve_criador($moodle_curso->id);
     \core\notification::success('Usuário criador matriculado como "professor".');
 
+    // captura as informacoes dos cargos
+    $cargos_atuacao = Atuacao::cargos_atuacao();
+
     // caso tenham sido passados outros usuarios, eh preciso inscreve-los
     if (isset($info_forms_array['ministrantes'])) {
       foreach ($info_forms_array['ministrantes'] as $id_ministrante=>$nome) {
@@ -90,10 +93,13 @@ class Ambiente {
         $codatc = Usuario::codigo_atuacao_ceu($usuario_moodle->idnumber, $info_forms->codofeatvceu);
         // matricula o professor
         Usuario::matricula_professor($moodle_curso->id, $id_ministrante, $codatc);
-        $shortname_adaptado = Atuacao::NOMES[$codatc];
+        // Nome do cargo
+        $shortname_adaptado = "-";
+        if (isset($cargos_atuacao[$codatc]))
+          $shortname_adaptado = $cargos_atuacao[$codatc];
+        // notificacao
         \core\notification::success('Professor auxiliar ' . $nome . ' matriculado como "' . $shortname_adaptado . '".');
         Notificacoes::notificacao_inscricao($usuario_moodle, $moodle_curso);
-
       }
     }
     
@@ -128,16 +134,19 @@ class Ambiente {
         $codatc = Usuario::codigo_atuacao_ceu($usuario_moodle->idnumber, $info_forms->codofeatvceu);
         // matricula o professor
         Usuario::matricula_professor($moodle_curso->id, $ministrante->id, $codatc);
-        $shortname_adaptado = Atuacao::NOMES[$codatc];
+        // nome do cargo
+        $shortname_adaptado = "-";
+        if (isset($cargos_atuacao[$codatc]))
+          $shortname_adaptado = $cargos_atuacao[$codatc];
+        // notificacao
         \core\notification::success('Professor auxiliar ' . $nome . ' matriculado como "' . $shortname_adaptado . '".');
         try {
           Notificacoes::notificacao_inscricao($ministrante, $moodle_curso);
-      } catch (Exception $e) {
+        } catch (Exception $e) {
           // Se ocorrer um erro, ele sera capturado aqui e podemos lidar com ele
           // Por exemplo, podemos exibir uma mensagem de erro ou registrar o erro em um arquivo de log.
           echo "Ocorreu um erro: " . $e->getMessage();
-      }
-      
+        }
       }
     }
 

--- a/src/Atuacao.php
+++ b/src/Atuacao.php
@@ -1,26 +1,41 @@
 <?php
 
+require_once(__DIR__ . '/Service/Query.php');
+use block_extensao\Service\Query;
+
 class Atuacao {
-  const NOMES = array(
-    1 => 'Professor USP',
-    2 => 'Especialista',
-    3 => 'Monitor',
-    4 => 'Servidor',
-    5 => 'Professor HC - FM-USP',
-    6 => 'Tutor',
-    7 => 'Docente (S)',
-    8 => 'Preceptor (S)',
-    9 => 'Tutor (S)'
-  );
-  const CORRESPONDENCIA_MOODLE = array(
-    1 => 'editingteacher',
-    2 => 'editingteacher',
-    3 => 'teacher',
-    4 => 'teacher',
-    5 => 'editingteacher',
-    6 => 'teacher',
-    7 => 'editingteacher',
-    8 => 'teacher',
-    9 => 'teacher'
-  );
+  /**
+   * Relacao atual:
+   * 
+   * Professor USP              => editingteacher
+   * Especialista               => editingteacher
+   * Monitor                    => teacher
+   * Servidor                   => teacher
+   * Professor HC - FM-USP      => editingteacher
+   * Tutor                      => teacher
+   * Docente (S)                => teacher
+   * Preceptor (S)              => teacher
+   * Tutor (S)                  => teacher
+   * Coordenador de Estágio (S) => teacher
+   * Corresponsável             => teacher
+   * Responsável                => teacher
+   */
+  const CARGOS_EDITINGTEACHER = array(1,2,5,7);
+
+  static public function correspondencia_moodle ($codatc) {
+    if (array_search($codatc, self::CARGOS_EDITINGTEACHER))
+      return 'editingteacher';
+    else
+      return 'teacher';
+  }
+
+  static public function cargos_atuacao () {
+    $Query = new Query();
+    $cargos_base = $Query->cargos_atuacao();
+    $cargos = array();
+    foreach ($cargos_base as $cargo) {
+      $cargos[$cargo['codatc']] = $cargo['dscatc'];
+    }
+    return $cargos;
+  }
 }

--- a/src/Service/Query.php
+++ b/src/Service/Query.php
@@ -25,6 +25,7 @@ class Query
     $this->CURSOCEU                 = get_config('block_extensao', 'tabela_cursoceu');
     $this->EDICAOCURSOOFECEU        = get_config('block_extensao', 'tabela_edicaocursoofeceu');
     $this->MINISTRANTECEU           = get_config('block_extensao', 'tabela_ministranteceu');
+    $this->ATUACAOCEU               = get_config('block_extensao', 'tabela_atuacaoceu');
     $this->EMAILPESSOA              = get_config('block_extensao', 'tabela_emailpessoa');
     $this->UNIDADE                  = get_config('block_extensao', 'tabela_unidade');
     $this->CAMPUS                   = get_config('block_extensao', 'tabela_campus');
@@ -43,7 +44,6 @@ class Query
    * Sao consideradas como turmas abertas somente as turmas com
    * data de encerramento posterior a data de hoje.
    */
-
   
   public function turmasAbertas () {
     
@@ -92,15 +92,18 @@ class Query
    * Captura os ministrantes das turmas informadas.
    * 
    * Os codigos de atuacao (codatc) conforme ATUACAOCEU sao:
-   * 1 - Professor USP
-   * 2 - Especialista
-   * 3 - Monitor
-   * 4 - Servidor
-   * 5 - Professor HC - FM-USP
-   * 6 - Tutor
-   * 7 - Docente (S)
-   * 8 - Preceptor (S)
-   * 9 - Tutor (S)
+   * 1  - Professor USP
+   * 2  - Especialista
+   * 3  - Monitor
+   * 4  - Servidor
+   * 5  - Professor HC - FM-USP
+   * 6  - Tutor
+   * 7  - Docente (S)
+   * 8  - Preceptor (S)
+   * 9  - Tutor (S)
+   * 10 - Coordenador de Estágio (S)
+   * 11 - Corresponsável
+   * 11 - Responsável
    * 
    * @param array $codofeatvceu_turmas Lista de codigos de oferecimento
    * das turmas.
@@ -141,6 +144,7 @@ class Query
     $query = "
       SELECT
         codund,
+        numseqofeedi,
         dtainiofeatv,
         dtafimofeatv
       FROM " . $this->OFERECIMENTOATIVIDADECEU . "
@@ -157,6 +161,7 @@ class Query
     $info_curso->codofeatvceu = $codofeatvceu;
     $info_curso->startdate = strtotime($infos_curso['dtainiofeatv']);
     $info_curso->enddate = strtotime($infos_curso['dtafimofeatv']);
+    $info_curso->numseqofeedi = $infos_curso['numseqofeedi'];
     return $info_curso;
   }
   
@@ -292,4 +297,14 @@ class Query
       WHERE codpes = $query_codpes
     ");
   }
+
+  /**
+   * Captura dos cargos cadastrados na base, para exibir as
+   * descricoes.
+   * 
+   * @return array
+   */
+  public function cargos_atuacao () {
+    return USPDatabase::fetchAll("SELECT * FROM " . $this->ATUACAOCEU);
+  } 
 }

--- a/src/Usuario.php
+++ b/src/Usuario.php
@@ -75,7 +75,7 @@ class Usuario {
     global $DB;
 
     // captura o shortname do codigo de atuacao
-    $shortname_codatc = Atuacao::CORRESPONDENCIA_MOODLE[$codatc];
+    $shortname_codatc = Atuacao::correspondencia_moodle($codatc);
 
     // captura o papel do shortname
     $role = $DB->get_record('role', ['shortname' => $shortname_codatc]);

--- a/version.php
+++ b/version.php
@@ -3,4 +3,4 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'block_extensao';
-$plugin->version = 2024022602;
+$plugin->version = 2024050202;


### PR DESCRIPTION
Foi adicionado ao forms de criação do curso, a informação do número de sequência do oferecimento. O processo foi realizado sem problemas, no entanto, a maioria dos cursos apresenta o número 1 como sequência de oferecimento. Dessa forma, o objetivo de melhorar a identificação do curso não foi alcançado, tendo em vista que todos as sequências são iguais, o que torna inviável a identificação por este código.