### PR TITLE
Alterações referentes ao commit #75

### DIFF
--- a/lang/en/block_extensao.php
+++ b/lang/en/block_extensao.php
@@ -13,3 +13,19 @@ $string['notificacao_inscricao_assunto'] = 'Course environment created';
 // Error handling  
 $string['erro_padrao'] = 'Error, please contact support!';
 $string['erro_profSemEmail'] = 'Attention, the selected teacher does not have an email address registered in the system, and therefore the registration notification will not be sent.';
+
+// Additional period
+$string['periodo_adicional'] = 'Additional period';
+$string['periodo_adicional_help'] = 'Attention! This is the original completion date for your Moodle course. An additional period has been added. After the end of this period, students will no longer be able to access the course or content.';
+
+// Other ministers
+$string['outros_ministrantes'] = 'Add Other instructors';
+$string['outros_ministrantes_help'] = 'Additional instructors available for the course will appear here. Please select the teachers you wish to add to the virtual learning environment.';
+
+// Available Courses
+$string['cursos_disponiveis'] = 'Available courses for creation';
+$string['cursos_disponiveis_help'] = 'Important! The courses listed below are ready for creation. Please select the course(s) you are interested in and click on "Create Environment" to proceed with more details.';
+
+// Course Description
+$string['descricao_curso'] = 'Course Description';
+$string['descricao_curso_help'] = 'Insert a brief description of your course, visible to both students and visitors.';

--- a/lang/pt_br/block_extensao.php
+++ b/lang/pt_br/block_extensao.php
@@ -13,3 +13,19 @@ $string['notificacao_inscricao_assunto'] = 'Ambiente de curso criado';
 // Tratamento de erros 
 $string['erro_padrao'] = 'Erro, por favor contate o suporte!';
 $string['erro_profSemEmail'] = 'Atenção, o professor selecionado não possui um e-mail cadastrado no sistema, e assim a notificação de inscrição não será enviada.';
+
+// Aviso de ajuda para as datas dos cursos 
+$string['periodo_adicional'] = 'Período adicional';
+$string['periodo_adicional_help'] = 'Atenção! Esta é a data original de término do seu curso no Moodle. Um período adicional foi acrescentado. Após o término deste período, os alunos não terão mais acesso à disciplina ou ao conteúdo.';
+
+// Outros ministrantes 
+$string['outros_ministrantes'] = 'Adicionar outros Ministrantes';
+$string['outros_ministrantes_help'] = 'Ministrantes adicionais disponíveis para o curso aparecerão aqui. Por favor, selecione os docentes que deseja adicionar ao ambiente virtual.';
+
+// Cursos disponiveis  
+$string['cursos_disponiveis'] = 'Cursos disponíveis para criação';
+$string['cursos_disponiveis_help'] = 'Importante! Os cursos listados abaixo estão prontos para serem criados. Selecione o(s) curso(s) de seu interesse e clique em "Criar Ambiente" para obter mais detalhes.';
+
+// Descricao do curso
+$string['descricao_curso'] = 'Descrição do Curso';
+$string['descricao_curso_help'] = 'Insira uma breve descrição do seu curso, visível para alunos e visitantes.';

--- a/utils/forms.php
+++ b/utils/forms.php
@@ -42,6 +42,10 @@ class redirecionamento_criacao_ambiente_select extends moodleform {
     $options = array('placeholder' => "Buscar") + $options;
     $this->_form->addElement('autocomplete', 'select_ambiente', 'Buscar por turma', $options);
 
+    // botao de ajuda com os cursos disponiveis para o ministrante 
+    $this->_form->addHelpButton('select_ambiente',  'cursos_disponiveis', 'block_extensao');
+
+
     // botao de submit
     $this->_form->addElement('submit', 'redirecionar_criar_ambiente', 'Criar ambiente');
   }
@@ -74,7 +78,7 @@ class redirecionamento_criacao_ambiente_lista extends moodleform {
     }
     $this->_form->addElement('hidden', 'codofeatvceu', $codofeatvceu);
     $this->_form->setType('codofeatvceu', PARAM_TEXT);
-    
+
     // botao de submit
     $this->_form->addElement('submit', 'redirecionar_criar_ambiente', 'Criar ambiente');
   }
@@ -113,19 +117,28 @@ class criar_ambiente_moodle extends moodleform {
     // data do fim do curso
     $end_date = (int) $this->define_campo('enddate');
     $periodo_adicional = get_config('block_extensao', 'periodoAdicional');
+    $first_enddate = date('d/m/Y', $end_date);
     $end_date = strtotime("+$periodo_adicional months", $end_date);
+
+    // Adiciona o seletor de data ao formulário
     $this->_form->addElement('date_selector', 'enddate', 'Data do fim do curso');
     $this->_form->setDefault('enddate', $end_date);
+
+    // Adiciona o botao de ajuda ao campo 'enddate'
+    $this->_form->addHelpButton('enddate', 'periodo_adicional', 'block_extensao');
 
     // Para definir um estilo 
     $end_date_formatted = date('d/m/Y', $end_date);
     $end_date_element = $this->_form->getElement('enddate');
-    $end_date_element->setLabel('Data do fim do curso <span style="color: #ff0000; font-weight: bold;">' . $end_date_formatted . '</span>');
+    $end_date_element->setLabel('Data do fim do curso <span style="color: #ff0000; font-weight: bold;">' . $first_enddate . '</span>');
 
     // sumario (descricao) do curso
     $summary = $this->define_campo('summary');
     $this->_form->addElement('editor', 'summary', 'Descrição do curso')->setValue(array('text'=>$summary));
     $this->_form->setType('summary', PARAM_RAW);
+
+    // Adiciona o botao de ajuda ao campo  summary
+    $this->_form->addHelpButton('summary', 'descricao_curso', 'block_extensao');
 
     // opcao para acesso de visitantes
     $guest = $this->define_campo('guest');
@@ -138,9 +151,14 @@ class criar_ambiente_moodle extends moodleform {
     ); 
 
     // opcao para inscrever outros ministrantes
+    // Define o campo para inscrever outros ministrantes
     $ministrantes = $this->define_campo('ministrantes');
-    
+    // Adiciona um cabecalho ao formulario para a secao de outros ministrantes
     $this->_form->addElement('header', 'header_ministrantes', 'Outros ministrantes');
+
+    // Adiciona um botao de ajuda ao cabecalho de 'Outros ministrantes' 
+    $this->_form->addHelpButton('header_ministrantes',  'outros_ministrantes', 'block_extensao');
+
 
     if (!isset($ministrantes['moodle']) or $ministrantes == "") {
       $this->_form->addElement(


### PR DESCRIPTION
Foram adicionados 4 botões de ajuda no estilo pop-up para o plugin, com orientações referentes aos campos do plugin, sendo eles respectivamente “Busca por turma”, “Data do fim do curso”, “Descrição do curso ” e  “Outros ministrantes”. Os pop-ups estão disponíveis em inglês e português.